### PR TITLE
Replacing {format} with json Fix #1

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -20,7 +20,7 @@ module.exports = function getSchema(listingUrl, callback){
         if(waitCounter === 0) callback(null, resourceListing)
       }
 
-      var declarationUrl = resourceObject.path;
+      var declarationUrl = resourceObject.path.replace('{format}', 'json');
       
       getApiDeclarations(listingUrl, declarationUrl, apiDeclarationHandler);
     });


### PR DESCRIPTION
Swagger might use {format} suffix instead of json, breaking the fetching of schema
