### PR TITLE
Enable basepath

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -23,7 +23,8 @@ module.exports = function getSchema(listingUrl, callback){
       }
 
       var declarationUrl = resourceObject.path.replace('{format}', 'json');
-      getApiDeclarations(listingUrl, declarationUrl, apiDeclarationHandler);
+      var baseUrl = resourceListing.basePath || listingUrl;
+      getApiDeclarations(baseUrl, declarationUrl, apiDeclarationHandler);
     });
 
   };
@@ -43,8 +44,11 @@ function getApiDeclarationUrl(listingUrl, declarationUrl) {
   // declaration path should be relative, but may be absolute
   declarationUrl = url.parse(declarationUrl);
   if(declarationUrl.hostname) return url.format(declarationUrl);
-
-  listingUrl.pathname += declarationUrl.path;
+  
+  if (listingUrl.pathname[listingUrl.pathname.length - 1] == '/') {
+    listingUrl.pathname = listingUrl.pathname.substr(0, listingUrl.pathname.length - 1);
+  }
+  listingUrl.pathname += declarationUrl.pathname;
   return url.format(listingUrl);
 }
 


### PR DESCRIPTION
{
 "apiVersion":"0.8.0",
 "swaggerVersion":"1.2",
 "basePath":"http://localhost:8080",
 "apis":[{"path":"/restdocs/bindings"}]
}

basepath wasn't handled
